### PR TITLE
 fix: exclude test files from Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,22 @@
 node_modules
 dist
+
+# Test files
+**/test/
+**/*.test.ts
+**/*.test.tsx
+**/*.test.js
+**/*.test.jsx
+**/coverage/
+
+# Environment files
+.env.local
+.env.*.local
+
+# IDE files
+.vscode/
+.idea/
+
+# Git
+.git/
+.gitignore


### PR DESCRIPTION
## Changes
Updated `.dockerignore` to exclude test files from Docker production builds.

### Files Changed
- `.dockerignore` - Added exclusions for test files, coverage, and development-only files

### What's excluded now:
- `**/test/` directories
- `**/*.test.ts`, `**/*.test.tsx`, `**/*.test.js`, `**/*.test.jsx`
- `**/coverage/`
- `.env.local`, `.env.*.local`
- IDE files (`.vscode/`, `.idea/`)
- Git files (`.git/`, `.gitignore`)

## Why
- **Fixes build failures**: Outdated/broken test files were causing TypeScript compilation errors in production builds
- **Best practice**: Test files don't belong in production containers
- **Performance**: Smaller images, faster builds
- **Security**: Reduces attack surface by not shipping test code

## Testing
 `docker compose up --build` - builds successfully
 Frontend accessible at http://localhost:3000
 Backend accessible at http://localhost:8080
 Both services run without errors

Closes #54 